### PR TITLE
Rework how caching works

### DIFF
--- a/.github/workflows/continue-release.yml
+++ b/.github/workflows/continue-release.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: ~/.m2/repository
-          key: m2-repository-cache-${{ steps.get-release-information.outputs.branch }}
+          key: m2-repository-cache-continue-${{ steps.get-release-information.outputs.branch }}
       - name: Clean up cache
         run: |
           [ -d ~/.m2/repository/io/quarkus ] && find ~/.m2/repository/io/quarkus -name 999-SNAPSHOT -type d -exec rm -rf {} +
@@ -128,7 +128,7 @@ jobs:
         uses: actions/cache/save@v3
         with:
           path: ~/.m2/repository
-          key: m2-repository-cache-${{ steps.get-release-information.outputs.branch }}
+          key: m2-repository-cache-continue-${{ steps.get-release-information.outputs.branch }}
       - name: Post interaction comment
         uses: quarkusio/conversational-release-action@main
         if: always()

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -52,14 +52,6 @@ jobs:
           java-version: ${{ steps.get-release-information.outputs.jdk }}
           # we do not define the server credentials here as we need to keep the github repository credentials around for executing the GitHub Action
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-      - name: Restore ~/.m2/repository cache
-        uses: actions/cache/restore@v3
-        with:
-          path: ~/.m2/repository
-          key: m2-repository-cache-${{ steps.get-release-information.outputs.branch }}
-      - name: Clean up cache
-        run: |
-          [ -d ~/.m2/repository/io/quarkus ] && find ~/.m2/repository/io/quarkus -name 999-SNAPSHOT -type d -exec rm -rf {} +
       - name: Push Maven server settings
         run: |
           sed -i "s@</servers>@<server><id>ossrh</id><username>${{ secrets.MAVEN_SERVER_USERNAME }}</username><password>${{ secrets.MAVEN_SERVER_PASSWORD }}</password></server></servers>@" ~/.m2/settings.xml
@@ -101,12 +93,6 @@ jobs:
         run: |
           [ -d ~/.m2/repository/io/quarkus ] && [ -n "${{ steps.release.outputs.version }}" ] && find ~/.m2/repository/io/quarkus -name ${{ steps.release.outputs.version }} -type d -exec rm -rf {} +
           [ -d ~/.m2/repository/io/quarkus ] && find ~/.m2/repository/io/quarkus -name 999-SNAPSHOT -type d -exec rm -rf {} +
-      - name: Save ~/.m2/repository cache
-        if: always()
-        uses: actions/cache/save@v3
-        with:
-          path: ~/.m2/repository
-          key: m2-repository-cache-${{ steps.get-release-information.outputs.branch }}
       - name: Post interaction comment
         uses: quarkusio/conversational-release-action@main
         if: always()


### PR DESCRIPTION
- Do not cache things for start-release.yml: we start from a fresh cache for each release and 2 workflows can't share a cache
- Cache in start-release.yml specifically