### PR TITLE
Simplify setup

### DIFF
--- a/.github/workflows/continue-release.yml
+++ b/.github/workflows/continue-release.yml
@@ -22,11 +22,6 @@ jobs:
     steps:
       - name: Display external IP address
         run: curl 'https://api64.ipify.org?format=json' || true
-      - name: Set up Java environment
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 11
       - name: Provide visual feedback
         uses: quarkusio/conversational-release-action@main
         with:
@@ -92,8 +87,6 @@ jobs:
           mkdir ~/.gradle
           echo "gradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }}" > ~/.gradle/gradle.properties
           echo "gradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }}" >> ~/.gradle/gradle.properties
-      - name: Set up JBang
-        uses: jbangdev/setup-jbang@main
       - name: Continue release
         id: release
         uses: quarkusio/conversational-release-action@main

--- a/.github/workflows/monitor-artifact-publication.yml
+++ b/.github/workflows/monitor-artifact-publication.yml
@@ -49,11 +49,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Java environment
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 21
       - name: Monitor artifact publication
         uses: quarkusio/monitor-artifact-publication-action@main
         with:

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -16,11 +16,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Java environment
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 11
       - name: Provide visual feedback
         uses: quarkusio/conversational-release-action@main
         with:
@@ -60,8 +55,6 @@ jobs:
           mkdir ~/.gradle
           echo "gradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }}" > ~/.gradle/gradle.properties
           echo "gradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }}" >> ~/.gradle/gradle.properties
-      - name: Set up JBang
-        uses: jbangdev/setup-jbang@main
       - name: Start release
         id: release
         uses: quarkusio/conversational-release-action@main

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+.vscode/


### PR DESCRIPTION
- We don't need to install a JDK first as the actions now use a JDK downloaded by JBang
- We don't need to install JBang ourselves as the actions install it anyway