### PR TITLE
Adjust the .m2 repo cache strategy

### DIFF
--- a/.github/workflows/continue-release.yml
+++ b/.github/workflows/continue-release.yml
@@ -75,7 +75,9 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: ~/.m2/repository
-          key: m2-repository-cache-continue-${{ steps.get-release-information.outputs.branch }}
+          # This will never work but it should fallback to the restore key below and get the latest cache for this branch
+          key: m2-repository-cache-continue-${{ steps.get-release-information.outputs.branch }}-${{ github.run_id }}
+          restore-keys: m2-repository-cache-continue-${{ steps.get-release-information.outputs.branch }}-
       - name: Clean up cache
         run: |
           [ -d ~/.m2/repository/io/quarkus ] && find ~/.m2/repository/io/quarkus -name 999-SNAPSHOT -type d -exec rm -rf {} +
@@ -123,7 +125,8 @@ jobs:
         uses: actions/cache/save@v3
         with:
           path: ~/.m2/repository
-          key: m2-repository-cache-continue-${{ steps.get-release-information.outputs.branch }}
+          # A cache cannot be updated so we use a unique id, we use prefix matching restore-keys to restore the cache
+          key: m2-repository-cache-continue-${{ steps.get-release-information.outputs.branch }}-${{ github.run_id }}
       - name: Post interaction comment
         uses: quarkusio/conversational-release-action@main
         if: always()


### PR DESCRIPTION
GitHub Actions caches cannot be updated. So we make the cache key unique and use prefix matching restore keys to use the latest cache that match the branch prefix.